### PR TITLE
Show proper error message as received in results data

### DIFF
--- a/src/BatchedGraphQLClient.ts
+++ b/src/BatchedGraphQLClient.ts
@@ -69,7 +69,8 @@ export class BatchedGraphQLClient {
       }
     } else {
       // if it is not an array, there must be an error
-      throw new ClientError({ ...results, status: response.status })
+      const error = results && results.error ? (response.status + ", Error : " + results.error) : response.status;
+      throw new ClientError({ ...results, status: error })
     }
   }
 }


### PR DESCRIPTION
This is w.r.t https://github.com/graphcool/http-link-dataloader/issues/4.
We need to fix the underlying issue, but this atleast shows the proper error.
**Earlier response** : 
`{
  "data": null,
  "errors": [
    {
      "message": "GraphQL Error (Code: 200)",
    }
  ]
}`
**New response** :
`{
  "data": null,
  "errors": [
    {
      "message": "GraphQL Error (Code: 200, Error : Your token is invalid. It might have expired or you might be using a token from a different project.)",
    }
  ]
}`

The error message helps to root cause much faster