### PR TITLE
Handle non-array errors gracefully

### DIFF
--- a/src/BatchedGraphQLClient.ts
+++ b/src/BatchedGraphQLClient.ts
@@ -56,7 +56,19 @@ export class BatchedGraphQLClient {
 
     // if it is not an array, there must be an error
     if (!Array.isArray(results)) {
-      throw new ClientError({ ...results, status: response.status })
+      let errorDetails;
+
+      if (typeof results === "string") {
+        errorDetails = {
+          errors: [{ message: `Invalid response: ${results}` }]
+        }
+      } else {
+        errorDetails = results;
+      }
+      throw new ClientError({
+        ...errorDetails,
+        status: response.status
+      })
     }
 
     // check if there was an error in one of the responses

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -28,6 +28,58 @@ test('extra fetch options', async t => {
   )
 })
 
+test('unexpected responses provide useful errors', async t => {
+  const client = new BatchedGraphQLClient('https://test.localhost/graphql1')
+
+  fetchMock.mock({
+    matcher: 'https://test.localhost/graphql1',
+    response: {
+      headers: { 'Content-Type': 'text/html' },
+      body: "<html>foo!</html>",
+    },
+  })
+
+  const error = await t.throws(client.request('{ test }'))
+  t.is(error.message, "Invalid response: <html>foo!</html>")
+})
+
+test('graphql errors', async t => {
+  const client = new BatchedGraphQLClient('https://test.localhost/graphql2')
+
+  fetchMock.mock({
+    matcher: 'https://test.localhost/graphql2',
+    response: {
+      headers: { 'Content-Type': 'application/json' },
+      body: [
+        { data: { test: 'test' } },
+        { errors: [{ message: 'it is on fire' }] }
+      ],
+    },
+  })
+
+  const error = await t.throws(client.request('{ test }'))
+  t.is(error.message, 'it is on fire')
+})
+
+test('strange JSON errors', async t => {
+  const client = new BatchedGraphQLClient('https://test.localhost/graphql3')
+
+  fetchMock.mock({
+    matcher: 'https://test.localhost/graphql3',
+    response: {
+      headers: { 'Content-Type': 'application/json' },
+      body: {
+        message: 'Something went wrong!',
+        errors: [{ message: 'it broke' }]
+      },
+    },
+  })
+
+  const error = await t.throws(client.request('{ test }'))
+  t.is(error.message, 'it broke')
+})
+
+
 async function mock(response: any, testFn: () => Promise<void>) {
   fetchMock.mock({
     matcher: '*',


### PR DESCRIPTION
If `results` is not an array here, something has probably gone really wrong.

In production we're typically seeing this when some part of the world between our GraphQL server and client blows up and returns an HTML error page. Spreading `results` when it's a string creates really unusable errors like this:

```
GraphQL Error: {
  "0": "\n",
  "1": "<",
  "2": "!",
  "3": "d",
  "4": "o",
  "5": "c",
  "6": "t",
  "7": "y",
  "8": "p",
  "9": "e",
  "10": " ",
  "11": "h",
  "12": "t",
  "13": "m",
  "14": "l",
  "15": ">",
  "16": "\n",
  "17": "<",
  "18": "h",
  "19": "t",
  "20": "m",
  "21": "l",
  "22": ">",
  "23": "\n",
  "24": "<",
  "25": "h",
  "26": "e",
  "27": "a",
  "28": "d",
  "29": ">",
  "30": "\n",
  "31": " ",
  "32": " ",
  "33": " ",
  "34": " ",
  "35": "<",
  "36": "t",
  "37": "i",
  "38": "t",
  "39": "l",
  "40": "e",
  "41": ">",
  "42": "E",
  "43": "x",
  "44": "a",
  "45": "m",
  "46": "p",
  "47": "l",
  "48": "e",
  "49": " ",
  "50": "D",
  "51": "o",
  "52": "m",
  "53": "a",
  "54": "i",
  "55": "n",
  "56": "<",
  "57": "/",
  "58": "t",
  "59": "i",
  "60": "t",
  "61": "l",
  "62": "e",
  "63": ">",
  "64": "\n",
  "65": "\n",
  "66": " ",
  "67": " ",
  "68": " ",
  "69": " ",

... snipped!

  "1252": "/",
  "1253": "h",
  "1254": "t",
  "1255": "m",
  "1256": "l",
  "1257": ">",
  "1258": "\n",
  "status": 502
}
```

With this change it'd instead be the slightly-more-debuggable:

```
Invalid response: \n<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n\n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color: #fff;\n        }\n        div {\n            width: auto;\n            margin: 0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n    }\n    </style>\n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is established to be used for illustrative examples in documents. You may use this\n    domain in examples without prior coordination or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n
```

@timsuchanek 👋 hi! Do you think it'd be suitable to get this in and bump prisma-binding?